### PR TITLE
Add childBuilder option

### DIFF
--- a/lib/pull_to_reveal.dart
+++ b/lib/pull_to_reveal.dart
@@ -2,15 +2,14 @@ import 'dart:math';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/material.dart';
 
-typedef ChildBuilder = ListView Function(
-    {ScrollController controller, ScrollPhysics physics});
+/// Signature for the function called to  create the [ListView] child.
+typedef ChildBuilder = ListView Function({ScrollController controller, ScrollPhysics physics});
 
 /// Combination of [BouncingScrollPhysics] and [AlwaysScrollableScrollPhysics]
 /// which creates the iOS-style bouncing scroll even on when the page is not
 /// completely full on Android devices.
 class AlwaysBouncableScrollPhysics extends BouncingScrollPhysics {
-  const AlwaysBouncableScrollPhysics({ScrollPhysics parent})
-      : super(parent: parent);
+  const AlwaysBouncableScrollPhysics({ScrollPhysics parent}) : super(parent: parent);
 
   @override
   AlwaysBouncableScrollPhysics applyTo(ScrollPhysics ancestor) {
@@ -49,11 +48,9 @@ enum ScrollSource {
 typedef RevealableToggler = void Function({RevealableCompleter completer});
 
 /// Builder function for a "revealable" widget based on user scrolling.
-typedef RevealableBuilder = Widget Function(
-    BuildContext, RevealableToggler, RevealableToggler, BoxConstraints);
+typedef RevealableBuilder = Widget Function(BuildContext, RevealableToggler, RevealableToggler, BoxConstraints);
 
-Widget emptyTopBuilder(BuildContext context, RevealableToggler opener,
-    RevealableToggler closer, BoxConstraints constraints) {
+Widget emptyTopBuilder(BuildContext context, RevealableToggler opener, RevealableToggler closer, BoxConstraints constraints) {
   return Container();
 }
 
@@ -100,8 +97,8 @@ class PullToRevealTopItemList extends StatefulWidget {
     this.startRevealed = false,
     @required this.revealableBuilder,
     @required this.revealableHeight,
-    this.itemBuilder,
     this.childBuilder,
+    this.itemBuilder,
     this.opacityThresholdToReveal = 0.5,
     this.animationRuntime = 300,
     this.revealableCompleter = RevealableCompleter.animate,
@@ -117,8 +114,7 @@ class PullToRevealTopItemList extends StatefulWidget {
 
 enum RevealableState { closed, closing, userScrolling, opening, open }
 
-class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
-    with TickerProviderStateMixin {
+class PullToRevealTopItemListState extends State<PullToRevealTopItemList> with TickerProviderStateMixin {
   RevealableState _revealableState;
   ScrollDirection _scrollDirection = ScrollDirection.idle;
 
@@ -144,8 +140,7 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
     _revealableHeight = widget.revealableHeight;
     _opacityThresholdToReveal = widget.opacityThresholdToReveal;
     _revealableOpacity = widget.startRevealed ? 1 : 0;
-    _revealableState =
-        widget.startRevealed ? RevealableState.open : RevealableState.closed;
+    _revealableState = widget.startRevealed ? RevealableState.open : RevealableState.closed;
     _animationRuntime = widget.animationRuntime;
     _revealableCompleter = widget.revealableCompleter;
     _lastEndScrollPosition = 0;
@@ -201,8 +196,7 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
       } else {
         // Still scrolling enough to completely add revealable
         setToUserScrolling();
-        double _tmpRevealableOpacity =
-            (pix / _revealableHeight).clamp(0.0, 1.0);
+        double _tmpRevealableOpacity = (pix / _revealableHeight).clamp(0.0, 1.0);
         _revealableOpacity = max(_tmpRevealableOpacity, _revealableOpacity);
       }
     });
@@ -223,9 +217,7 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
       } else {
         // Still removing the revealable
         setToUserScrolling();
-        _revealableOpacity =
-            ((_revealableHeight - scrolledPixels) / _revealableHeight)
-                .clamp(0.0, 1.0);
+        _revealableOpacity = ((_revealableHeight - scrolledPixels) / _revealableHeight).clamp(0.0, 1.0);
       }
     });
   }
@@ -271,40 +263,27 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
   /// abandoned scrolling that may need a partially rendered revealable to be
   /// ushered to one of the two complete stays (fully hidden or fully revealed).
   void _onUpdateScroll(ScrollUpdateNotification notification) {
-    double scrolledPixels =
-        notification.metrics.pixels - _lastEndScrollPosition;
-    _scrollDirection =
-        scrolledPixels > 0 ? ScrollDirection.forward : ScrollDirection.reverse;
-    ScrollSource scrollSource = notification.dragDetails != null
-        ? ScrollSource.userAction
-        : ScrollSource.automatedRebound;
-    if (scrollSource == ScrollSource.userAction &&
-        _scrollDirection == ScrollDirection.forward &&
-        (isOpen || isOpening)) {
+    double scrolledPixels = notification.metrics.pixels - _lastEndScrollPosition;
+    _scrollDirection = scrolledPixels > 0 ? ScrollDirection.forward : ScrollDirection.reverse;
+    ScrollSource scrollSource = notification.dragDetails != null ? ScrollSource.userAction : ScrollSource.automatedRebound;
+    if (scrollSource == ScrollSource.userAction && _scrollDirection == ScrollDirection.forward && (isOpen || isOpening)) {
       setToUserScrolling();
     }
-    if (scrollSource == ScrollSource.userAction &&
-        _scrollDirection == ScrollDirection.reverse &&
-        (isClosed || isClosing)) {
+    if (scrollSource == ScrollSource.userAction && _scrollDirection == ScrollDirection.reverse && (isClosed || isClosing)) {
       setToUserScrolling();
     }
     if (!isUserScrolling) {
       return;
     }
-    bool _isDragRelease =
-        _lastDragDetails != null && notification.dragDetails == null;
+    bool _isDragRelease = _lastDragDetails != null && notification.dragDetails == null;
     _lastDragDetails = notification.dragDetails;
     // Pushing content up (ScrollDirection.forward)
     if (scrolledPixels > 0) {
-      _isDragRelease
-          ? _endedPushUp()
-          : _continuePushingContentUp(scrolledPixels);
+      _isDragRelease ? _endedPushUp() : _continuePushingContentUp(scrolledPixels);
 
       // Pulling content down (ScrollDirection.reverse)
     } else if (scrolledPixels < 0) {
-      _isDragRelease
-          ? _endedPullDown()
-          : _continuePullingContentDown(scrolledPixels.abs());
+      _isDragRelease ? _endedPullDown() : _continuePullingContentDown(scrolledPixels.abs());
     }
   }
 
@@ -318,17 +297,12 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
   void _onEndScroll(ScrollEndNotification notification) async {
     _lastEndScrollPosition = notification.metrics.pixels;
     // Set value to zero if below zero
-    _lastEndScrollPosition =
-        _lastEndScrollPosition > 0 ? _lastEndScrollPosition : 0;
+    _lastEndScrollPosition = _lastEndScrollPosition > 0 ? _lastEndScrollPosition : 0;
 
     // Pushing content up and not already closing
-    if (_scrollDirection == ScrollDirection.forward &&
-        !isClosed &&
-        !isClosing) {
+    if (_scrollDirection == ScrollDirection.forward && !isClosed && !isClosing) {
       _closer();
-    } else if (_scrollDirection == ScrollDirection.reverse &&
-        !isOpen &&
-        !isOpening) {
+    } else if (_scrollDirection == ScrollDirection.reverse && !isOpen && !isOpening) {
       _concludeReveal();
     }
   }
@@ -344,13 +318,11 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
   void _animateOpen() {
     setToOpening();
     double _startingOpacity = _revealableOpacity;
-    _openController = AnimationController(
-        duration: Duration(milliseconds: runtime), vsync: this);
+    _openController = AnimationController(duration: Duration(milliseconds: runtime), vsync: this);
     _openAnimation = Tween<double>(begin: 0, end: 1).animate(_openController)
       ..addListener(() {
         setState(() {
-          _revealableOpacity =
-              (_openAnimation.value + _startingOpacity).clamp(0.0, 1.0);
+          _revealableOpacity = (_openAnimation.value + _startingOpacity).clamp(0.0, 1.0);
         });
       })
       ..addStatusListener((state) {
@@ -365,21 +337,19 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
   void _animateClosed() {
     setToClosing();
     double _startingOpacity = _revealableOpacity;
-    _closeController = AnimationController(
-        duration: Duration(milliseconds: runtime), vsync: this);
-    _closeAnimation =
-        Tween<double>(begin: 1.0, end: 0).animate(_closeController)
-          ..addListener(() {
-            setState(() {
-              _revealableOpacity = _closeAnimation.value * _startingOpacity;
-            });
-          })
-          ..addStatusListener((state) {
-            if (state == AnimationStatus.completed) {
-              setToClosed();
-              _revealableOpacity = 0;
-            }
-          });
+    _closeController = AnimationController(duration: Duration(milliseconds: runtime), vsync: this);
+    _closeAnimation = Tween<double>(begin: 1.0, end: 0).animate(_closeController)
+      ..addListener(() {
+        setState(() {
+          _revealableOpacity = _closeAnimation.value * _startingOpacity;
+        });
+      })
+      ..addStatusListener((state) {
+        if (state == AnimationStatus.completed) {
+          setToClosed();
+          _revealableOpacity = 0;
+        }
+      });
     _closeController.forward();
   }
 
@@ -429,10 +399,8 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
 
   @override
   Widget build(BuildContext context) {
-    bool isEmptyAndForceOnEmpty =
-        widget.itemCount == 0 && widget.revealWhenEmpty;
-    double opacity =
-        (isEmptyAndForceOnEmpty || isOpen) ? 1.0 : _revealableOpacity;
+    bool isEmptyAndForceOnEmpty = widget.itemCount == 0 && widget.revealWhenEmpty;
+    double opacity = (isEmptyAndForceOnEmpty || isOpen) ? 1.0 : _revealableOpacity;
     return Column(
       children: <Widget>[
         Revealable(
@@ -442,9 +410,7 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
           opener: _opener,
           closer: _closer,
         ),
-        widget.dividerBuilder != null
-            ? widget.dividerBuilder(context)
-            : Container(),
+        widget.dividerBuilder != null ? widget.dividerBuilder(context) : Container(),
         Expanded(
           child: NotificationListener<ScrollNotification>(
             onNotification: (scrollNotification) {
@@ -456,19 +422,20 @@ class PullToRevealTopItemListState extends State<PullToRevealTopItemList>
               // This return value continues event propagation
               return null;
             },
-            child: (widget.childBuilder != null)
+            child: 
+            (widget.childBuilder != null)
                 ? widget.childBuilder(
                     controller: _scrollController,
                     physics: AlwaysBouncableScrollPhysics(),
-                  )
-                : ListView.builder(
-                    controller: _scrollController,
-                    // iOS-style physics for everyone, since Android by default
-                    // doesn't allow scrolling higher than the highest content
-                    physics: AlwaysBouncableScrollPhysics(),
-                    itemCount: widget.itemCount,
-                    itemBuilder: widget.itemBuilder,
-                  ),
+                  ) 
+                :ListView.builder(
+                  controller: _scrollController,
+                  // iOS-style physics for everyone, since Android by default
+                  // doesn't allow scrolling higher than the highest content
+                  physics: AlwaysBouncableScrollPhysics(),
+                  itemCount: widget.itemCount,
+                  itemBuilder: widget.itemBuilder,
+            ),
           ),
         ),
       ],


### PR DESCRIPTION
Added an alternative childBuilder to the itemBuilder which allows for extending the ListView under the control the PullToRevealTopItem widget.  The childBuilder must return a ListView and takes the scroll controller and physics as required arguments.

As a possible use case...  Use a GroupedListView (https://pub.dev/packages/grouped_list) as the child.